### PR TITLE
Fixed blocks are read repeatedly in infinite cycle

### DIFF
--- a/demo/exchange/index.js
+++ b/demo/exchange/index.js
@@ -56,7 +56,12 @@ async function iterateTransfers(client) {
 
     // Reads first 100 transfers and print their details
     for (let i = 0; i < 100; i += 1) {
-        dumpTransfer(await transfers.next());
+        const record = await transfers.next()
+        if (record) {
+            dumpTransfer(record)
+        } else {
+            break
+        }
     }
 
     // We can suspend current iteration and get suspended state
@@ -72,7 +77,12 @@ async function iterateTransfers(client) {
     // the previously suspended state.
     const resumed = await TransferIterator.resume(client, [], suspended);
     for (let i = 0; i < 40; i += 1) {
-        dumpTransfer(await resumed.next());
+        const record = await resumed.next()
+        if (record) {
+            dumpTransfer(record)
+        } else {
+            break
+        }
     }
 }
 

--- a/demo/exchange/transfers.js
+++ b/demo/exchange/transfers.js
@@ -221,7 +221,6 @@ class TransferIterator {
     async _nextPortion() {
         /** @type {string[]} */
         const transactionIds = [];
-        const blocks = this._blocks.clone();
         while (transactionIds.length < 50) {
             let block = await this._blocks.next();
             if (!block) {
@@ -239,7 +238,7 @@ class TransferIterator {
         }
         this._portion = await TransferIterator._queryTransfers(this.client, transactionIds);
         this._nextIndex = 0;
-        this._blocks = blocks;
+        this._blocks = this._blocks.clone();
     }
 
 }


### PR DESCRIPTION
1. Fixed: blocks are read repeatedly in infinite cycle
  How to reproduce:
  ``` 
  npm i
  node index.js | tee log.txt
  ```
  Abort execution after a 2 minutes and open `log.txt` in a editor. You can find any block hash several times,  or just see output `$ sort log.txt` 


2. Add guard condition in an example
